### PR TITLE
Unnecessary isEmpty method

### DIFF
--- a/lib/src/helpers/auth_string_extension.dart
+++ b/lib/src/helpers/auth_string_extension.dart
@@ -1,3 +1,3 @@
 extension AuthStringExtension on String {
-  bool get isNotBlank => isNotEmpty && !contains(' ');
+  bool get isNotBlank => isNotEmpty // && !contains(' '); ==> this should change or removed.
 }

--- a/lib/src/helpers/auth_string_extension.dart
+++ b/lib/src/helpers/auth_string_extension.dart
@@ -1,3 +1,3 @@
 extension AuthStringExtension on String {
-  bool get isNotBlank => isNotEmpty // && !contains(' '); ==> this should change or removed.
+  bool get isNotBlank => isNotEmpty; // && !contains(' '); ==> this should change or removed.
 }


### PR DESCRIPTION
```dart
extension AuthStringExtension on String {
  bool get isNotBlank => isNotEmpty && !contains(' ');
```

the second condition, "contains", make it impossible to create a custom button with empty characters. It will fall into assert.

I would suggest that we can remove it and "isNotEmpty" is enough for it.