### PR TITLE
Update google fonts to 6.1.0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1+1"
+    version: "3.0.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -118,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: google_fonts
-      sha256: e20ff62b158b96f392bfc8afe29dee1503c94fbea2cbe8186fd59b756b8ae982
+      sha256: f0b8d115a13ecf827013ec9fc883390ccc0e87a96ed5347a3114cac177ef18e8
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "6.1.0"
   http:
     dependency: transitive
     description:

--- a/lib/src/buttons/apple_auth_button.dart
+++ b/lib/src/buttons/apple_auth_button.dart
@@ -99,7 +99,7 @@ class AppleAuthButton extends AuthButton {
   @override
   TextStyle? resolveTextStyle(Set<MaterialState> states) {
     return GoogleFonts.getFont(
-      'Source Sans Pro',
+      'Source Sans 3',
       fontWeight: FontWeight.w600,
       fontSize: 18,
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: e20ff62b158b96f392bfc8afe29dee1503c94fbea2cbe8186fd59b756b8ae982
+      sha256: f0b8d115a13ecf827013ec9fc883390ccc0e87a96ed5347a3114cac177ef18e8
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "6.1.0"
   http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.7
-  google_fonts: ^5.1.0
+  google_fonts: ^6.1.0
 
 dev_dependencies:
   flutter_lints: ^2.0.3


### PR DESCRIPTION
I updated the google_fonts dependency to their latest version, 6.1.0. This broke the Apple auth button, as the font `Source Sans Pro` is no longer part of the font set. 

I researched and used `Source Sans 3` as a replacement. I enclosed a side-to-side comparison below. The fonts are virtually identical. 

![image](https://github.com/elbeicktalat/flutter_auth_buttons/assets/19547190/1788616a-f0a7-4460-85b6-a7e23154a805)
